### PR TITLE
[COPE-784] Update API docs to include g as weight unit

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -578,7 +578,11 @@ definitions:
         example: 20
       unit:
         type: string
-        description: The unit of weight for the package. Can be either `lb` or `kg`.
+        description: |-
+          The unit of weight for the package. Can be either:
+          - `lb`
+          - `g`
+          - `kg`
         example: lb
     required:
       - weight


### PR DESCRIPTION
<img width="404" alt="Screenshot 2024-07-02 at 4 03 53 PM" src="https://github.com/SecondCloset/parcel-api-docs/assets/29466297/30034a75-4ce0-4d30-9ef1-8afa90e2f5cd">
