### PR TITLE
Update Label Service docs

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -170,25 +170,42 @@ paths:
       tags:
         - "Labels"
       description: >-
-        This endpoint retrieves a label (zpl, pdf or pdf_letter) from an orderId. The pdf_letter format fits a full standard letter page with a dotted line to cut the label.
+        This endpoint retrieves a label from an orde ID.
       summary: Retrieve Labels
       parameters:
         - name: orderId
           in: path
           description: The id of the order that we want to get the label from
           required: true
-          type: string
+          schema:
+            type: string
         - name: format
           in: query
-          description: format of the label (zpl, pdf or pdf_letter)
+          description: Desired format of the label. The `PDF_LETTER` format fits a full standard letter page with a dotted line to cut the label. Formats `PDF` and `PDF_LETTER` will respond with PDF files.
           required: true
-          type: string
+          schema:
+            type: string
+            enum:
+              - ZPL
+              - PDF
+              - PNG
+              - PDF_BASE64
+              - PDF_LETTER
+
       security:
         - Oauth2: []
         - Authorization-Header: []
       responses:
         200:
-          description: "the label in zpl or pdf file"
+          description: The label in indicated format
+          examples:
+            zpl:
+              $ref: "#/components/examples/zplExample"
+            png:
+              $ref: "#/components/examples/pngExample"
+            pdf_base64:
+              $ref: "#/components/examples/pdfBase64Example"
+
   /orders:
     x-summary: Orders
     post:
@@ -535,7 +552,7 @@ definitions:
         type: number
         description: The longitude value of the location
         example: -73.61911979999999
-  
+
   LocationSummary:
     title: Location Summary
     type: object
@@ -1142,3 +1159,13 @@ definitions:
             type: string
             description: The date of creation of the last order in the query.
             example: "2019-10-25T22:56:06.000Z"
+
+components:
+  examples:
+    zplExample: "^XA^FO100,100^B3N,N,100,Y,N^FD123456^FS^XZ"
+    pngExample:
+      url: "https://res.cloudinary.com/second-closet/image/upload/v1720639681/LTWSJELEB7JK.png"
+    pdfBase64Example:
+      orderId: "LTWSJELEB7JK"
+      carrier: "GoBolt"
+      label: "JVBERi0xLjMKJf////8KMTMgMCBvYmoKPDwKL1ByZWRpY3RvciAxNQovQ29sb3JzIDEK..."

--- a/swagger.yml
+++ b/swagger.yml
@@ -170,7 +170,7 @@ paths:
       tags:
         - "Labels"
       description: >-
-        This endpoint retrieves a label from an orde ID.
+        This endpoint retrieves a label from an order ID.
       summary: Retrieve Labels
       parameters:
         - name: orderId


### PR DESCRIPTION
We did not have any useful docs for label service expected response. I updated the description and added some examples.

<img width="1512" alt="Screenshot 2024-07-10 at 4 04 30 PM" src="https://github.com/SecondCloset/parcel-api-docs/assets/24196428/18311878-a39b-40d7-b715-062c47f2c8d8">
<img width="486" alt="Screenshot 2024-07-10 at 4 04 32 PM" src="https://github.com/SecondCloset/parcel-api-docs/assets/24196428/94f8c3a5-df09-472a-84b1-e79c1be3b82c">
<img width="448" alt="Screenshot 2024-07-10 at 4 04 34 PM" src="https://github.com/SecondCloset/parcel-api-docs/assets/24196428/2c1695d8-af8c-4be3-8e99-0b00c52274b7">
<img width="492" alt="Screenshot 2024-07-10 at 4 04 39 PM" src="https://github.com/SecondCloset/parcel-api-docs/assets/24196428/c808b50b-0e16-48a3-828f-b74f2ca97f8c">
