### PR TITLE
[COPE-806] Update order creation recipient name, street, and unit with max length restrictions

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -446,6 +446,7 @@ definitions:
         type: string
         description: The full name of the recipient.
         example: Charles Carmichael
+        maxLength: 82
       phone:
         type: string
         description: The phone number of the recipient in the following format +1<area code><10 digit phone number>
@@ -472,10 +473,12 @@ definitions:
         type: string
         description: The street number and street name of the address. If needed, the street number postfix can be included as well.
         example: 4455A Boul. Poirier
+        maxLength: 82
       unit:
         type: string
         description: The unit, apartment and/or business name of the address. This property is not parsed during the geolocation of the address and can be descriptive.
         example: unit204 - GoBolt HQ
+        maxLength: 82
       city:
         type: string
         description: The city or municipality of the address.


### PR DESCRIPTION
See context [here](https://goboltlogistics.slack.com/archives/C04Q4PY3FPA/p1721321235769619?thread_ts=1721298167.271229&cid=C04Q4PY3FPA) on why we are setting these character limits to 82 characters

<img width="697" alt="Screenshot 2024-07-16 at 5 57 42 PM" src="https://github.com/user-attachments/assets/8480f439-11f6-4a5e-a16b-85949deb3d23">
