### PR TITLE
[COPE-357] Add sortCode to API docs

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -1100,6 +1100,10 @@ definitions:
         type: string
         description: A display name that's going to be shown in the order's label
         example: Metro Fleury No 2
+      sortCode:
+        type: string
+        description: A zone code designated based on the customer's postal address
+        example: "A"
 
   AuthTokenRequest:
     title: Auth Token Request


### PR DESCRIPTION
We need to add `sortCode` to our API docs to see if Zara/Inditex can build their labels (aka, add zone code) by grabbing it via our Get Orders API

<img width="588" alt="image" src="https://github.com/user-attachments/assets/42c23a1c-b64c-4047-bc6e-003e2586c396" />
