### PR TITLE
[COPE-477] Update docs to reflect changes for Samsung integration changes

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -501,7 +501,7 @@ definitions:
         example: H4R 2A4
       isBusinessAddress:
         type: boolean
-        description: This optional field let's us know if the recipient address is a business address. This allows us to do our best to ensure that the delivery is completed during business hours, or retrieve an alternate address from the recipient.The postal code of the address.
+        description: This optional field let's us know if the recipient address is a business address. This allows us to do our best to ensure that the delivery is completed during business hours, or retrieve an alternate address from the recipient.
         example: true
     required:
       - street

--- a/swagger.yml
+++ b/swagger.yml
@@ -310,7 +310,7 @@ paths:
       tags:
         - "Orders"
       description: >-
-        This endpoint modifies the packages in an order. The number of packages in the new package list must be the same as the original order. The weight of each new package should not exceed the weight limit set for the original order's delivery type. For instance, if the original order is labeled as `PARCEL`, the weights of the new packages must stay within the `PARCEL` limit.
+        This endpoint modifies the packages in an order. The number of packages in the new package list must be the same as the original order.
       summary: Update the packages in an order.
       security:
         - OAuth2: []
@@ -610,7 +610,7 @@ definitions:
   WeightOptions:
     title: WeightOptions
     type: object
-    description: The weight of the package. Orders will be classified as `HEAVY` if any of its package are over 50lbs.
+    description: The weight of the package. Orders will be classified as `HEAVY` if the service selected is `CUSTOMER_BOOKING`.
     properties:
       weight:
         type: integer
@@ -759,7 +759,7 @@ definitions:
         type: string
         enum: *service
         default: NEXTDAY
-        description: The service of the order, which determines the price and speed of the delivery. `CUSTOMER_BOOKING` is the only applicable option for `HEAVY` orders.
+        description: The service of the order, which determines the price and speed of the delivery.
       deliveryService:
         type: string
         enum: *deliveryService
@@ -1042,7 +1042,7 @@ definitions:
           service:
             type: string
             enum: *service
-            description: The service of the order, which determines the price and speed of the delivery. `CUSTOMER_BOOKING` is the only applicable option for `HEAVY` orders.
+            description: The service of the order, which determines the price and speed of the delivery.
             example: "NEXTDAY"
           deliveryService:
             type: string
@@ -1167,7 +1167,7 @@ definitions:
         service:
           type: string
           enum: *service
-          description: A code representing the service level for the rate. `CUSTOMER_BOOKING` is the only applicable option for `HEAVY` orders.
+          description: A code representing the service level for the rate.
         name:
           type: string
           description: The human readable name for the rate.


### PR DESCRIPTION
With the Samsung Integration, we are expanding our NEXTDAY sevice to handle any weight (instead of the 50lbs limitation before). We realized that the `deliveryType` values of `HEAVY` and `PARCEL` dictate what happens downstream (do we choose GoBolt Parcel or GoBolt Last Mile) and is not related to the actual weight of the packages.

I found and removed any references to `HEAVY`/`PARCEL` or `50lbs` if they mentioned some logic (i.e. you can only update weights in the same delivery type)