### PR TITLE
[MINI-1394] Update failed reasons

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -919,18 +919,28 @@ definitions:
                 - `OUT_FOR_DELIVERY`:
                   - `Package has left warehouse`
                 - `FAILED` (can be one of the following):
-                  - `Delivery unsuccessful`
-                  - `Delivery unsuccessful - loading issue`
-                  - `Delivery unsuccessful - address issue`
-                  - `Delivery attempted - customer not at home`
-                  - `Delivery attempted - business closed`
-                  - `Delivery attempted - unable to drop`
-                  - `Delivery unsuccessful - unable to access`
-                  - `Delivery unsuccessful - damaged items`
-                  - `Delivery attempted - refused by customer`
-                  - `Delivery unsuccessful - issue on route`
-                  - `Delivery unsuccessful - lost package`
-                  - `Delivery unsuccessful - return to merchant`
+                  - `Delivery Unsuccessful`
+                  - `Delivery Unsuccessful - Order Incomplete`
+                  - `Delivery Attempted - Address Issue`
+                  - `Delivery Attempted - Customer Unavailable`
+                  - `Delivery Attempted - Business is Closed`
+                  - `Delivery Unsuccessful - Unable to drop package(s)`
+                  - `Delivery Unsuccessful - Unable to access`
+                  - `Delivery Exception - Damaged Packages`
+                  - `Delivery Attempted - Customer Refused`
+                  - `Delivery Exception - Unable to complete route`
+                  - `Lost Package(s)`
+                  - `Returning to Sender`
+                  - `Delivery Exception - Damaged Upon Receiving`
+                  - `Delivery Attempted - Customer Moved`
+                  - `Delivery Unsuccessful - Address missing house or unit number`
+                  - `Delivery Attempted - Address missing buzz code`
+                  - `Delivery Unsuccessful - Address Issue`
+                  - `Delivery Unsuccessful - Unable to access gated community`
+                  - `Delivery Exception - Weather`
+                  - `Delivery Exception - Road Closure`
+                  - `Delivery Unsuccessful - Unable to complete route`
+                  - `Returning to Origin Facility`
                 - `DELIVERED`:
                   - `Package delivered`
                 - `RETURN_TO_SENDER`:


### PR DESCRIPTION
## Ticket

https://linear.app/gobolt/issue/MINI-1394/add-new-fail-reasons-with-dropdown-options

## Description

We deployed new failed reasons on Wed, Jun 18th. I forgot to update our API docs to reflect these changes

## Screenshots/Videos

### Before
<img width="485" alt="Screenshot 2025-06-23 at 4 46 39 PM" src="https://github.com/user-attachments/assets/ef6979e9-af39-40b2-94ac-502b1f33327b" />

### After
<img width="563" alt="Screenshot 2025-06-23 at 4 46 32 PM" src="https://github.com/user-attachments/assets/91cba219-a5e2-438e-9870-a332c5e095c2" />

