### PR TITLE
[MINI-2470] Add secondaryRefNumber to Order API

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -801,6 +801,10 @@ definitions:
         type: string
         description: A reference number from your side that we can use to contact you about the order
         example: shopifyid1234
+      secondaryRefNumber:
+        type: string
+        description: A seondary reference number from your side that we can use to contact you about the order
+        example: seoncdaryid1234
       merchantDisplayName:
         type: string
         description: A display name that's going to be shown in the order's label
@@ -1111,6 +1115,10 @@ definitions:
         type: string
         description: A reference number from your side that we can use to contact you about the order
         example: shopifyid1234
+      secondaryRefNumber:
+        type: string
+        description: A seondary reference number from your side that we can use to contact you about the order
+        example: seoncdaryid1234
       completeAfter:
         type: number
         description: epoch (milliseconds) of the beginning of pickup window (need to be later than right now)


### PR DESCRIPTION
## Ticket Link

https://linear.app/gobolt/issue/MINI-2470/add-secondaryrefnumber-to-api-docs

## Description

This is the last step for the Aritzia go-live and will allow other merchants to be aware of the `secondaryRefNumber`. 

I'll merge this in once I send Daniel a demo of the `secondaryRefNumber` and he gives me the green light on it

## Screenshots/Videos

<img width="1680" height="673" alt="Screenshot 2025-12-01 at 9 27 30 PM" src="https://github.com/user-attachments/assets/0950912b-e319-4a11-a1f7-8d7485336b22" />
