### PR TITLE
[MINI-2814] Remove any reference of the pickup ready flow

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -331,32 +331,6 @@ paths:
         200:
           description: "Successful response"
 
-  /orders/{id}/pickupready:
-    x-summary: Mark an order as ready for pickup. Also referred to as confirming an order or fulfilling an order.
-    patch:
-      tags:
-        - "Orders"
-      description: >-
-        This endpoint marks an order as ready for pickup. Also referred to as confirming an order or fulfilling an order.
-      summary: Mark order as ready for pickup.
-      security:
-        - OAuth2: []
-        - Authorization-Header: []
-      parameters:
-        - name: id
-          in: path
-          description: The id of the order that will be updated
-          required: true
-          type: string
-        - name: body
-          in: body
-          required: true
-          schema:
-            type: object
-      responses:
-        200:
-          description: "Successful response"
-
   /orders/{id}/updateOrder:
     x-summary: Update Order Info
     patch:
@@ -427,7 +401,6 @@ definitions:
       - RATE_FAILED
       - UNSUPPORTED_WEIGHT
       - GEOCODED
-      - PICKUP_READY
       - CARRIER_PICKED_UP
       - SHIPMENT_CREATED
       - SHIPMENT_PROCESSING
@@ -971,8 +944,6 @@ definitions:
                   - `Order weight is outside of the supported weight band`
                 - `GEOCODED`:
                   - `Address has been validated`
-                - `PICKUP_READY`:
-                  - `Packages are ready for pick-up`
                 - `CARRIER_PICKED_UP`:
                   - `Carrier has picked up the packages`
                 - `SHIPMENT_CREATED`:


### PR DESCRIPTION
## Ticket Link

https://linear.app/gobolt/issue/MINI-2814/remove-pick-up-ready-flow

## Description

Now that [Zara is off of the pickup ready flow](https://linear.app/gobolt/issue/MINI-2813/move-zara-off-of-pickupready-flow), all merchants are on the AUTO flow. We can start cleaning up references to the pickup-ready flow in our API docs, as we plan to deprecate it entirely.

## Screenshots/Videos

### Before

<img width="1685" height="705" alt="Screenshot 2026-02-04 at 2 05 11 PM" src="https://github.com/user-attachments/assets/acab1d76-0cb1-42d3-9be1-a3026322141e" />

### After (pickup ready tab is gone)

<img width="307" height="281" alt="Screenshot 2026-02-04 at 3 06 23 PM" src="https://github.com/user-attachments/assets/e7d22290-6c7a-4b88-b6df-53675aa6f0ba" />



